### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-app-deployment.yml
+++ b/.github/workflows/contoso-traders-app-deployment.yml
@@ -3,6 +3,9 @@ name: contoso-traders-app-deployment
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   ACR_NAME: contosotradersacr
   AKS_CLUSTER_NAME: contoso-traders-aks


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1338/devsecops/security/code-scanning/3](https://github.com/github-cloudlabsuser-1338/devsecops/security/code-scanning/3)

To fix the issue, add a `permissions` block to the root of the workflow or the `provision` job. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations in the workflow, the `contents: read` permission is likely sufficient for most steps, with additional permissions (e.g., `packages: write`) added only if necessary.

The `permissions` block should be added at the root level to apply to all jobs unless overridden by a job-specific `permissions` block. This ensures consistency and reduces the risk of missing permissions in individual jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
