### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-provisioning-deployment.yml
+++ b/.github/workflows/contoso-traders-provisioning-deployment.yml
@@ -1,5 +1,8 @@
 name: contoso-traders-provisioning-deployment
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1338/devsecops/security/code-scanning/2](https://github.com/github-cloudlabsuser-1338/devsecops/security/code-scanning/2)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should be added at the root level of the workflow to apply to all jobs unless overridden. Based on the workflow's operations, the minimal permissions required are likely `contents: read`, as the workflow does not appear to modify repository contents or interact with pull requests.

Steps to implement the fix:
1. Add a `permissions` block at the root level of the workflow file.
2. Set `contents: read` to limit the `GITHUB_TOKEN` to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
