### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-contoso-traders-app.yml
+++ b/.github/workflows/update-contoso-traders-app.yml
@@ -3,6 +3,9 @@ name: update contoso traders app
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   # You can specify any location for `SUB_DEPLOYMENT_REGION`. It's the region where the deployment
   # metadata will be stored, and not where the resource groups will be deployed.


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1338/devsecops/security/code-scanning/1](https://github.com/github-cloudlabsuser-1338/devsecops/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves checking out code and interacting with Azure resources, the `contents: read` permission is sufficient for the `GITHUB_TOKEN`. This ensures that the token cannot perform write operations unless explicitly required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `provision` job to scope permissions specifically to that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
